### PR TITLE
chore: track workspace repo + require PRs for local config changes

### DIFF
--- a/repositories.config.json
+++ b/repositories.config.json
@@ -100,5 +100,11 @@
     "type": "product-analytics",
     "package": "altertable-rust",
     "registry": "crates-io"
+  },
+  {
+    "repo": "altertable-ai/albert-workspace",
+    "type": "workspace",
+    "package": "albert-workspace",
+    "registry": "none"
   }
 ]

--- a/rules/change-control.md
+++ b/rules/change-control.md
@@ -7,6 +7,7 @@ All workspace changes go through PRs in [altertable-ai/albert-workspace](https:/
 | `SOUL.md`, `AGENTS.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, `HEARTBEAT.md` | PR required. Explain why. |
 | `MEMORY.md` | PR required. Public — only write what you'd be comfortable the team and internet seeing. |
 | `rules/`, `skills/` | PR required. |
+| Local configuration (`repositories.config.json`, bootstrap scripts, workspace behavior) | PR required. Include a short rationale in the PR body so the team can track operational changes. |
 | `memory/` | Local only. Never committed or pushed. |
 
 Don't add files outside the defined structure without explaining the purpose in the PR.


### PR DESCRIPTION
## Summary
- add `altertable-ai/albert-workspace` to `repositories.config.json`
- codify that local configuration changes (including `repositories.config.json`, bootstrap scripts, and workspace behavior) must go through PRs

## Why
Keeps the core team aware of operational/setup changes made in Albert's local workspace configuration.
