### PR TITLE
docs(contribution): enforce no-drift PR title and description

### DIFF
--- a/rules/contribution.md
+++ b/rules/contribution.md
@@ -8,7 +8,11 @@ All work in `code/` (`.gitignored`, ephemeral). One branch per change, never mix
 2. **Clone** into `code/<repo-name>`, configure git identity (see `TOOLS.md`)
 3. **Branch** from upstream `main`: `fix/<issue>-<desc>` or `feat/<desc>`
 4. **Work** — commit, push to fork
-5. **Open PR** against upstream `main` — title must follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`) since all commits are squash-merged
+5. **Open PR** against upstream `main`
+   - PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`) since all commits are squash-merged
+   - PR title and PR description must always reflect the actual changes in the PR (no drift)
+   - If PR scope changes during review, update both title and description immediately before merge
+   - We squash-merge with the PR title + PR description, so they become part of permanent history
 6. **Clean up** after merge — delete fork branch and local clone
 
 ```bash


### PR DESCRIPTION
## Summary
- update `rules/contribution.md` PR workflow guidance
- require PR title and PR description to always match actual PR changes (no drift)
- require both title and description to be updated when scope changes during review
- clarify this is mandatory because squash merges preserve PR title + description as history
