### PR TITLE
docs(sdk-readme): strengthen modern OSS README playbook

### DIFF
--- a/skills/sdk-readme/SKILL.md
+++ b/skills/sdk-readme/SKILL.md
@@ -5,7 +5,7 @@ description: Defines how to write README files for Altertable open-source SDK re
 
 # SDK README
 
-Use this skill when writing or refactoring README files for Altertable SDK repositories.
+Use this skill when writing or refactoring README files for Altertable SDK repositories. Also called by `sdk-implement` Phase 7. Two README types: **monorepo root** and **package**.
 
 **Rules:** [quality](../../rules/quality.md) · [change-control](../../rules/change-control.md)
 


### PR DESCRIPTION
## Summary
- expand  with a modern OSS README baseline
- tighten required monorepo root README structure and conventions
- tighten package README section order + per-section content rules
- add style/format guidance and a pre-commit review checklist

## Why
This makes README quality expectations explicit and consistent before running cross-repo sweeps.

## Validation
- reviewed the updated skill for section order, required fields, and references consistency