### PR TITLE
fix(rules): prevent escaped newlines in GitHub markdown fields

### DIFF
--- a/rules/communication.md
+++ b/rules/communication.md
@@ -5,9 +5,9 @@
 - Reply to specific threads, not generic top-level comments.
 - Close the loop: acknowledge feedback, state what you did, mark resolved.
 - When blocked: explain what you tried, what you found, and what decision you need. Apply `needs-human-review`.
-- Within 5 minutes of posting, edit via `gh api PATCH` instead of adding a new comment — unless the update needs to surface as a new notification.
-  - Issue/PR comments: `PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}`
-  - PR body: `PATCH /repos/{owner}/{repo}/pulls/{pull_number}`
+- Within 5 minutes of posting, edit in place instead of adding a new comment — unless the update needs to surface as a new notification.
+  - Prefer `gh pr edit --body-file` for PR descriptions.
+  - Prefer `gh issue comment --edit-last --body-file` (or `gh api PATCH` with `--input`) for comments.
 
 ### Markdown-safe posting (required)
 
@@ -21,7 +21,22 @@ gh pr edit <n> --body-file - <<'EOF'
 EOF
 ```
 
-- If a post lands malformed, patch immediately with `gh ... --body-file` or `gh api PATCH`.
+For `gh api PATCH`, build payload JSON safely:
+
+```bash
+body_file=$(mktemp)
+cat > "$body_file" <<'MD'
+## Summary
+- first item
+MD
+
+jq -n --rawfile body "$body_file" '{body: $body}' > payload.json
+gh api repos/<owner>/<repo>/pulls/<number> --method PATCH --input payload.json
+```
+
+- Never send markdown bodies as JSON escaped strings like `"## Summary\\n- item"`; GitHub will render literal `\n`.
+- If you must use `gh api PATCH`, write a JSON payload file and pass it via `--input` so newlines are real newlines, not backslash-escaped shell text.
+- If a post lands malformed, patch immediately with `gh ... --body-file`.
 
 ## Slack
 


### PR DESCRIPTION
## Summary
- tighten `rules/communication.md` to avoid malformed markdown in GitHub fields
- require `--body-file` for PR/issue/comment markdown edits
- document the exact anti-pattern (`"...\\n..."`) that renders literal `\n`
- add a safe `gh api PATCH` example using `jq --rawfile` + `--input`

## Why
We keep seeing PR/issue bodies posted with escaped newlines (`\n`) instead of rendered markdown. This update makes the safe path explicit and gives a copy/paste-safe API flow when `gh api` is required.

## Validation
- updated PR #12 body using `gh pr edit --body-file`
- confirmed markdown now renders as headings and bullet lists instead of escaped text
