### PR TITLE
Enforce watch-all policy for repositories.config.json repos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,19 @@ Operating rules are broken into focused bricks in `rules/`. Load the bricks rele
 
 The canonical list of all SDK repositories lives in [repositories.config.json](repositories.config.json).
 
+All repositories listed in `repositories.config.json` must be watched (all activity) so maintainer notifications are complete.
+
+Enforce this with GitHub CLI:
+
+```bash
+jq -r '.[].repo' repositories.config.json | while read -r repo; do
+  gh api -X PUT "repos/$repo/subscription" -F subscribed=true -F ignored=false
+  gh api "repos/$repo/subscription" --jq '"\(.repository_url): subscribed=\(.subscribed) ignored=\(.ignored)"'
+done
+```
+
+Run this at session start (or heartbeat start) before triage/review.
+
 ## Skills
 
 Available skills in `skills/`:

--- a/skills/routine-maintainer/SKILL.md
+++ b/skills/routine-maintainer/SKILL.md
@@ -38,11 +38,14 @@ Dispatched by the heartbeat. Processes GitHub notifications and dispatches to `o
 ## Work Session
 
 1. **Assess scope** — is this isolated to one repo or ecosystem-wide? If ecosystem-wide, open a tracking issue via `bash scripts/upsert-github-issue.sh` rather than closing in isolation.
-2. **Check notifications** — `gh api notifications`
-3. **For each notification**: gather full context via GitHub API, determine action, add to prioritized list
-4. **Work through items** by priority. Close the loop on every thread. Mark notifications as read only after a visible outcome (comment, resolution, or explicit deferral): `gh api -X PATCH notifications/threads/{thread_id}`
-5. **PRs**: CI failing → fix + push; changes requested → address + re-request review; conflicts → rebase + push
-6. **Issues**: untriaged → `ops-triage`; needs response → answer or request info; needs repro → attempt locally
+2. **Enforce watch subscriptions for all supervised repositories** — from workspace root:
+   - `jq -r '.[].repo' repositories.config.json | while read -r repo; do gh api -X PUT "repos/$repo/subscription" -F subscribed=true -F ignored=false; done`
+   - verify: `jq -r '.[].repo' repositories.config.json | while read -r repo; do gh api "repos/$repo/subscription" --jq '"\(.repository_url): subscribed=\(.subscribed) ignored=\(.ignored)"'; done`
+3. **Check notifications** — `gh api notifications`
+4. **For each notification**: gather full context via GitHub API, determine action, add to prioritized list
+5. **Work through items** by priority. Close the loop on every thread. Mark notifications as read only after a visible outcome (comment, resolution, or explicit deferral): `gh api -X PATCH notifications/threads/{thread_id}`
+6. **PRs**: CI failing → fix + push; changes requested → address + re-request review; conflicts → rebase + push
+7. **Issues**: untriaged → `ops-triage`; needs response → answer or request info; needs repro → attempt locally
 
 ## Acceptance Checklist
 


### PR DESCRIPTION
## Summary
- update `AGENTS.md` to require watching **all** repositories listed in `repositories.config.json`
- replace per-assignment watch behavior with a deterministic watch-all loop using GitHub CLI
- update `skills/routine-maintainer/SKILL.md` to enforce and verify watch subscriptions before notifications triage

## Why
Reactive "watch on assignment" still leaves blind spots. A watch-all policy ensures the maintainer loop sees activity across the full supervised repo set.

## Commands codified
- enforce:
  - `jq -r '.[].repo' repositories.config.json | while read -r repo; do gh api -X PUT "repos/$repo/subscription" -F subscribed=true -F ignored=false; done`
- verify:
  - `jq -r '.[].repo' repositories.config.json | while read -r repo; do gh api "repos/$repo/subscription" --jq '"\(.repository_url): subscribed=\(.subscribed) ignored=\(.ignored)"'; done`
