### PR TITLE
Restructure repositories to separate workspace from SDKs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Operating rules are broken into focused bricks in `rules/`. Load the bricks rele
 
 ## Repositories Under Supervision
 
-The canonical list of all SDK repositories lives in [repositories.config.json](repositories.config.json).
+The canonical list of all repositories lives in [repositories.config.json](repositories.config.json).
 
 ## Skills
 

--- a/repositories.config.json
+++ b/repositories.config.json
@@ -1,110 +1,110 @@
-[
-  {
+{
+  "workspace": {
     "repo": "altertable-ai/albert-workspace",
-    "type": "workspace",
-    "package": "albert-workspace",
-    "registry": "none"
+    "package": "albert-workspace"
   },
-  {
-    "repo": "altertable-ai/altertable-lakehouse-ruby",
-    "type": "lakehouse",
-    "package": "altertable-lakehouse-ruby",
-    "registry": "rubygems"
-  },
-  {
-    "repo": "altertable-ai/altertable-lakehouse-python",
-    "type": "lakehouse",
-    "package": "altertable-lakehouse-python",
-    "registry": "pypi"
-  },
-  {
-    "repo": "altertable-ai/altertable-lakehouse-go",
-    "type": "lakehouse",
-    "package": "altertable-lakehouse-go",
-    "registry": "go-modules"
-  },
-  {
-    "repo": "altertable-ai/altertable-lakehouse-java",
-    "type": "lakehouse",
-    "package": "altertable-lakehouse-java",
-    "registry": "maven-central"
-  },
-  {
-    "repo": "altertable-ai/altertable-lakehouse-kotlin",
-    "type": "lakehouse",
-    "package": "altertable-lakehouse-kotlin",
-    "registry": "maven-central"
-  },
-  {
-    "repo": "altertable-ai/altertable-lakehouse-rust",
-    "type": "lakehouse",
-    "package": "altertable-lakehouse-rust",
-    "registry": "crates-io"
-  },
-  {
-    "repo": "altertable-ai/altertable-lakehouse-php",
-    "type": "lakehouse",
-    "package": "altertable-lakehouse-php",
-    "registry": "packagist"
-  },
-  {
-    "repo": "altertable-ai/altertable-lakehouse-cli",
-    "type": "lakehouse",
-    "package": "altertable-lakehouse-cli",
-    "registry": "github-releases"
-  },
-  {
-    "repo": "altertable-ai/altertable-js",
-    "type": "product-analytics",
-    "package": ["altertable-js", "altertable-react"],
-    "registry": "npm"
-  },
-  {
-    "repo": "altertable-ai/altertable-python",
-    "type": "product-analytics",
-    "package": "altertable-python",
-    "registry": "pypi"
-  },
-  {
-    "repo": "altertable-ai/altertable-swift",
-    "type": "product-analytics",
-    "package": "altertable-swift",
-    "registry": "swift-package-index"
-  },
-  {
-    "repo": "altertable-ai/altertable-kotlin",
-    "type": "product-analytics",
-    "package": "altertable-kotlin",
-    "registry": "maven-central"
-  },
-  {
-    "repo": "altertable-ai/altertable-ruby",
-    "type": "product-analytics",
-    "package": "altertable-ruby",
-    "registry": "rubygems"
-  },
-  {
-    "repo": "altertable-ai/altertable-java",
-    "type": "product-analytics",
-    "package": "altertable-java",
-    "registry": "maven-central"
-  },
-  {
-    "repo": "altertable-ai/altertable-go",
-    "type": "product-analytics",
-    "package": "altertable-go",
-    "registry": "go-modules"
-  },
-  {
-    "repo": "altertable-ai/altertable-php",
-    "type": "product-analytics",
-    "package": "altertable-php",
-    "registry": "packagist"
-  },
-  {
-    "repo": "altertable-ai/altertable-rust",
-    "type": "product-analytics",
-    "package": "altertable-rust",
-    "registry": "crates-io"
-  }
-]
+  "sdks": [
+    {
+      "repo": "altertable-ai/altertable-lakehouse-ruby",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-ruby",
+      "registry": "rubygems"
+    },
+    {
+      "repo": "altertable-ai/altertable-lakehouse-python",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-python",
+      "registry": "pypi"
+    },
+    {
+      "repo": "altertable-ai/altertable-lakehouse-go",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-go",
+      "registry": "go-modules"
+    },
+    {
+      "repo": "altertable-ai/altertable-lakehouse-java",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-java",
+      "registry": "maven-central"
+    },
+    {
+      "repo": "altertable-ai/altertable-lakehouse-kotlin",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-kotlin",
+      "registry": "maven-central"
+    },
+    {
+      "repo": "altertable-ai/altertable-lakehouse-rust",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-rust",
+      "registry": "crates-io"
+    },
+    {
+      "repo": "altertable-ai/altertable-lakehouse-php",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-php",
+      "registry": "packagist"
+    },
+    {
+      "repo": "altertable-ai/altertable-lakehouse-cli",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-cli",
+      "registry": "github-releases"
+    },
+    {
+      "repo": "altertable-ai/altertable-js",
+      "kind": "product-analytics",
+      "package": ["altertable-js", "altertable-react"],
+      "registry": "npm"
+    },
+    {
+      "repo": "altertable-ai/altertable-python",
+      "kind": "product-analytics",
+      "package": "altertable-python",
+      "registry": "pypi"
+    },
+    {
+      "repo": "altertable-ai/altertable-swift",
+      "kind": "product-analytics",
+      "package": "altertable-swift",
+      "registry": "swift-package-index"
+    },
+    {
+      "repo": "altertable-ai/altertable-kotlin",
+      "kind": "product-analytics",
+      "package": "altertable-kotlin",
+      "registry": "maven-central"
+    },
+    {
+      "repo": "altertable-ai/altertable-ruby",
+      "kind": "product-analytics",
+      "package": "altertable-ruby",
+      "registry": "rubygems"
+    },
+    {
+      "repo": "altertable-ai/altertable-java",
+      "kind": "product-analytics",
+      "package": "altertable-java",
+      "registry": "maven-central"
+    },
+    {
+      "repo": "altertable-ai/altertable-go",
+      "kind": "product-analytics",
+      "package": "altertable-go",
+      "registry": "go-modules"
+    },
+    {
+      "repo": "altertable-ai/altertable-php",
+      "kind": "product-analytics",
+      "package": "altertable-php",
+      "registry": "packagist"
+    },
+    {
+      "repo": "altertable-ai/altertable-rust",
+      "kind": "product-analytics",
+      "package": "altertable-rust",
+      "registry": "crates-io"
+    }
+  ]
+}

--- a/scripts/ecosystem-status.sh
+++ b/scripts/ecosystem-status.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SDK_REPOS=()
-while IFS= read -r line; do SDK_REPOS+=("$line"); done < <(jq -r '.[].repo' "${SCRIPT_DIR}/../repositories.config.json")
+while IFS= read -r line; do SDK_REPOS+=("$line"); done < <(jq -r '.sdks[].repo' "${SCRIPT_DIR}/../repositories.config.json")
 
 MARKDOWN=false
 JSON=false

--- a/scripts/spec-status.sh
+++ b/scripts/spec-status.sh
@@ -16,7 +16,7 @@ WORKSPACE_ROOT="${SCRIPT_DIR}/.."
 CACHE_FILE="${WORKSPACE_ROOT}/code/.last-spec-tag"
 
 SDK_REPOS=()
-while IFS= read -r line; do SDK_REPOS+=("$line"); done < <(jq -r '.[].repo' "${WORKSPACE_ROOT}/repositories.config.json")
+while IFS= read -r line; do SDK_REPOS+=("$line"); done < <(jq -r '.sdks[].repo' "${WORKSPACE_ROOT}/repositories.config.json")
 
 SPECS_REPO="altertable-ai/altertable-client-specs"
 MARKDOWN=false

--- a/scripts/subscribe-repos.sh
+++ b/scripts/subscribe-repos.sh
@@ -34,7 +34,7 @@ fi
 
 CONFIG_REPOS=()
 while IFS= read -r line; do CONFIG_REPOS+=("$line"); done \
-  < <(jq -r '.[].repo' "$CONFIG_FILE")
+  < <(jq -r '.sdks[].repo, .workspace.repo' "$CONFIG_FILE")
 
 # ── Load currently watched altertable-ai/* repos ──────────────────────────────
 # GitHub paginates at 100; loop pages until the response is empty.

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -183,7 +183,7 @@ Thanks for the PR. [Reason for closing — duplicate/out of scope/etc.]
 To find PRs awaiting review across all repos:
 
 ```bash
-for repo in $(jq -r '.[].repo' ../../repositories.config.json); do
+for repo in $(jq -r '.sdks[].repo' ../../repositories.config.json); do
   echo "=== $repo ==="
   gh pr list --repo "$repo" --state open --json number,title,author,createdAt \
     --jq '.[] | "\(.number)\t\(.author.login)\t\(.title)"'

--- a/skills/ops-triage/SKILL.md
+++ b/skills/ops-triage/SKILL.md
@@ -129,7 +129,7 @@ Issues with `stale` label and no activity for 7 more days:
 To triage all open unlabeled issues across repos:
 
 ```bash
-for repo in $(jq -r '.[].repo' ../../repositories.config.json); do
+for repo in $(jq -r '.sdks[].repo' ../../repositories.config.json); do
   echo "=== $repo ==="
   gh issue list --repo "$repo" --state open --json number,title,labels \
     --jq '.[] | select(.labels | length == 0) | "\(.number)\t\(.title)"'

--- a/skills/sdk-sync/SKILL.md
+++ b/skills/sdk-sync/SKILL.md
@@ -5,7 +5,7 @@ description: Keep shared configuration, community files, and CI templates consis
 
 # SDK Sync
 
-Audit and synchronize shared files across all Altertable SDK repositories. Repository inventory: [`repositories.config.json`](../../repositories.config.json) (each entry has `repo`, `type`, `package`, `registry`). Edit that file to add/remove repos — all scripts pick it up automatically.
+Audit and synchronize shared files across all Altertable SDK repositories. Repository inventory: [`repositories.config.json`](../../repositories.config.json). Edit that file to add/remove repos — all scripts pick it up automatically.
 
 **Rules:** [change-control](../../rules/change-control.md) · [contribution](../../rules/contribution.md) · [safety](../../rules/safety.md)
 
@@ -36,9 +36,10 @@ Templated files contain `{variable}` placeholders. Render them with repo-specifi
 
 ### Phase 1: Audit
 
-1. Clone or fetch all repos from `repositories.config.json`.
-2. For each managed file, compare the repo's version against the source of truth.
-3. Report drift:
+1. Read `repositories.config.json` and iterate over the `sdks` array (do not include the `workspace` entry).
+2. Clone or fetch all SDK repos from the `sdks` array.
+3. For each managed file, compare the repo's version against the source of truth.
+4. Report drift:
 
 ```text
 DRIFT REPORT
@@ -71,7 +72,7 @@ For each repo with changes:
 
 ## Adding a New Managed File
 
-When a new file should be consistent across all repos:
+When a new file should be consistent across all SDK repos:
 
 1. Add the file to the `templates/` folder at the path it should occupy in the target repo.
 2. If it needs per-repo values, use `{variable}` placeholders and add a row to the **Template variables** table above.
@@ -79,9 +80,9 @@ When a new file should be consistent across all repos:
 
 ## Acceptance Checklist
 
-- [ ] All repos in the inventory have been audited
+- [ ] All SDK repos in the inventory have been audited
 - [ ] Drift report generated for all managed files
 - [ ] Verbatim files are byte-identical across repos
 - [ ] Templated files use correct repo-specific values
-- [ ] PRs opened for all repos with drift
+- [ ] PRs opened for all SDK repos with drift
 - [ ] No files outside the managed list were modified


### PR DESCRIPTION
Restructures `repositories.config.json` from a flat array to a keyed object with `workspace` and `sdks` keys. This makes SDK repos explicit and removes the need for filtering. Also renames `type` to `kind` in SDK entries for clarity.

## Details

### Config Structure Change

The config now uses structure to convey meaning instead of relying on field values:

**Before:**
```json
[
  { "repo": "altertable-ai/albert-workspace", "type": "workspace", ... },
  { "repo": "altertable-ai/altertable-ruby", "type": "lakehouse", ... }
]
```

**After:**
```json
{
  "workspace": { "repo": "altertable-ai/albert-workspace", ... },
  "sdks": [
    { "repo": "altertable-ai/altertable-ruby", "kind": "lakehouse", ... }
  ]
}
```

This change makes SDK detection explicit at the schema level, eliminating the need for filtering logic across consumers.