### PR TITLE
Unify review workflow

### DIFF
--- a/rules/communication.md
+++ b/rules/communication.md
@@ -3,6 +3,7 @@
 ## GitHub
 
 - Reply to specific threads, not generic top-level comments.
+- Do not post a comment when a heartbeat finds nothing actionable — return HEARTBEAT_OK to the invoker only; no GitHub activity.
 - Close the loop: acknowledge feedback, state what you did, mark resolved.
 - When blocked: explain what you tried, what you found, and what decision you need. Apply `needs-human-review`.
 - Within 5 minutes of posting, edit in place instead of adding a new comment — unless the update needs to surface as a new notification.
@@ -21,21 +22,16 @@ gh pr edit <n> --body-file - <<'EOF'
 EOF
 ```
 
-For `gh api PATCH`, build payload JSON safely:
+For `gh api PATCH`, use `-F body=@-` to read the body from stdin (same heredoc pattern):
 
 ```bash
-body_file=$(mktemp)
-cat > "$body_file" <<'MD'
+gh api repos/<owner>/<repo>/pulls/<number> -X PATCH -F body=@- <<'EOF'
 ## Summary
-- first item
-MD
-
-jq -n --rawfile body "$body_file" '{body: $body}' > payload.json
-gh api repos/<owner>/<repo>/pulls/<number> --method PATCH --input payload.json
+- keep `inline-code` intact
+EOF
 ```
 
 - Never send markdown bodies as JSON escaped strings like `"## Summary\\n- item"`; GitHub will render literal `\n`.
-- If you must use `gh api PATCH`, write a JSON payload file and pass it via `--input` so newlines are real newlines, not backslash-escaped shell text.
 - If a post lands malformed, patch immediately with `gh ... --body-file`.
 
 ## Slack

--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -19,15 +19,15 @@ gh pr diff <number> --repo <repo>
 gh pr checks <number> --repo <repo>
 ```
 
-Note the PR author — first-time contributors need a more welcoming tone. Check whether the contributor has enabled "Allow edits by maintainers" — this determines whether a stacked PR is possible.
+Note the PR author — first-time contributors need a more welcoming tone, core team members do not (defined in [USER.md](../../USER.md)).
 
 ### Step 2: Check CI status
 
 All CI checks must pass before approving. If checks fail:
 
 1. Identify the failing job (lint, typecheck, test, integration)
-2. If the fix is obvious and small (e.g., a missing changelog entry, a formatting issue, a trivial lint error): push a fix directly to the contributor's branch (if they've allowed maintainer edits) or open a stacked PR per [rules/contribution.md](../../rules/contribution.md)
-3. Otherwise, comment with the failure and a clear suggestion to fix
+2. If the fix is obvious and small (e.g., a missing changelog entry, a formatting issue, a trivial lint error): open a stacked PR per [rules/contribution.md](../../rules/contribution.md)
+3. Otherwise: open a stacked PR with the fix, and for external contributors, comment with the failure and explain that you've opened a stacked PR to fix it — once merged, it'll automatically fix the contributor PR.
 
 ### Step 3: Review against standards
 
@@ -110,7 +110,7 @@ If the PR introduces a breaking change:
 |-----------|--------|
 | CI green, standards met, tests included | **Approve** |
 | Minor issues (typo, missing changelog entry, small style nit) | **Approve** with comments |
-| CI failing or minor issue with an obvious fix | **Push fix** to contributor's branch or open a stacked PR (see [rules/contribution.md](../../rules/contribution.md)) |
+| CI failing or minor issue with an obvious fix | **Open a stacked PR** (see [rules/contribution.md](../../rules/contribution.md)) |
 | Missing tests or incomplete implementation | **Request changes** |
 | Breaks public API without justification | **Request changes** |
 | Spam, off-topic, or fundamentally misguided approach | **Close** with explanation |


### PR DESCRIPTION
This PR standardizes the PR review workflow to always use stacked PRs instead of pushing directly to contributor branches, and simplifies communication rules for heartbeats and GitHub API usage.

## Details

### Communication rules (`rules/communication.md`)

- **Heartbeat**: Do not post a GitHub comment when a heartbeat finds nothing actionable — return `HEARTBEAT_OK` to the invoker only.
- **`gh api PATCH`**: Use `-F body=@-` to read the body from stdin (same heredoc pattern as `gh pr edit`), replacing the temp file + `jq` approach.
- Removed redundant guidance about JSON payload files.

### Review workflow (`skills/ops-review/SKILL.md`)

- **Author awareness**: Clarified that first-time contributors need a welcoming tone; core team members do not (see `USER.md`). Removed the “Allow edits by maintainers” check.
- **CI failures**: Always open a stacked PR for fixes instead of pushing to the contributor’s branch. For external contributors, comment that a stacked PR was opened and that merging it will fix their PR.
- **Decision table**: Replaced “Push fix to contributor’s branch or open stacked PR” with “Open a stacked PR” in all relevant cells.