### PR TITLE
Reduce noise, favor high-value bot interactions

### DIFF
--- a/skills/ops-review/SKILL.md
+++ b/skills/ops-review/SKILL.md
@@ -153,6 +153,10 @@ Thanks for your first contribution to {repo}! 🎉
 
 ### Approving
 
+When everything meets standards, approve without a comment — the approval itself is sufficient. Only add a brief note when welcoming a first-time contributor or when you want to highlight something specific.
+
+**Don't comment** just to say "LGTM" or "Approved" — the approval action speaks for itself.
+
 ```text
 Looks great — thanks for the contribution!
 ```
@@ -201,4 +205,5 @@ Process each PR through the review workflow above. Prioritize by age (oldest fir
 - [ ] Commit messages follow Conventional Commits
 - [ ] No hardcoded secrets or credentials
 - [ ] Breaking changes properly flagged (if applicable)
-- [ ] Review comment posted with clear, actionable feedback
+- [ ] Review submitted (approve / request changes / comment)
+- [ ] If feedback provided, it is clear and actionable

--- a/skills/ops-triage/SKILL.md
+++ b/skills/ops-triage/SKILL.md
@@ -138,9 +138,15 @@ done
 
 Process each unlabeled issue through the workflow above.
 
+## When to Comment
+
+- **Comment**: When the reporter needs to take action (e.g. add repro, provide info), when closing, or when you need to explain a decision (label, duplicate, etc.).
+- **Label only**: When adding a label is self-explanatory and no action is needed from the reporter (e.g. `enhancement` on a clear feature request).
+- **Don't comment**: When simply applying a label that's obvious from the issue content (e.g. labeling a clear bug report as `bug`), or when the label itself communicates everything needed.
+
 ## Response Templates
 
-Every triage response must follow a teammate-style structure so the reporter knows what happened and what to expect:
+Every non-empty triage action must store an entry in `memory/YYYY-MM-DD.md` with the following structure:
 
 1. **What I checked**: Brief summary of what you looked at (e.g. "Checked for duplicates", "Reviewed the repro steps")
 2. **What I need from you / what I changed**: Either the requested info or the action you took (labels, closure, etc.)

--- a/skills/routine-maintainer/SKILL.md
+++ b/skills/routine-maintainer/SKILL.md
@@ -40,7 +40,14 @@ Dispatched by the heartbeat. Processes GitHub notifications and dispatches to `o
 1. **Assess scope** — is this isolated to one repo or ecosystem-wide? If ecosystem-wide, open a tracking issue via `bash scripts/upsert-github-issue.sh` rather than closing in isolation.
 2. **Check notifications** — `gh api notifications`
 3. **For each notification**: gather full context via GitHub API, determine action, add to prioritized list
-4. **Work through items** by priority. Close the loop on every thread. Mark notifications as read only after a visible outcome (comment, resolution, or explicit deferral): `gh api -X PATCH notifications/threads/{thread_id}`
+4. **Work through items** by priority. Mark notifications as read when they don't require action, or after a valuable outcome (emoji reaction, comment, resolution, or explicit deferral): `gh api -X PATCH notifications/threads/{thread_id}`. If no visible action needed, store in `memory/YYYY-MM-DD.md`, no GitHub activity.
+
+   **Valuable outcome**: One that moves the thread forward — unblocks the author, clarifies next steps, or resolves the item.
+
+   **Avoid low-value comments**:
+   - Restating what the UI already shows (e.g. "CI is passing" when the green checkmark is visible)
+   - Obvious observations (e.g. "This PR adds a new function" when reviewing the diff)
+   - Redundant confirmations (e.g. "Approved!" when the approval badge is sufficient)
 5. **PRs**: CI failing → fix + push; changes requested → address + re-request review; conflicts → rebase + push
 6. **Issues**: untriaged → `ops-triage`; needs response → answer or request info; needs repro → attempt locally
 
@@ -49,6 +56,6 @@ Dispatched by the heartbeat. Processes GitHub notifications and dispatches to `o
 - [ ] Notifications checked and processed
 - [ ] PRs with failing CI identified and addressed
 - [ ] Issues triaged or responded to
-- [ ] Every acted-on notification has a visible response
+- [ ] Every notification is acted
 - [ ] Every processed notification marked as read
 - [ ] Blocked items have `needs-human-review` + team member tagged

--- a/skills/sdk-sync/SKILL.md
+++ b/skills/sdk-sync/SKILL.md
@@ -81,8 +81,8 @@ When a new file should be consistent across all SDK repos:
 ## Acceptance Checklist
 
 - [ ] All SDK repos in the inventory have been audited
-- [ ] Drift report generated for all managed files
+- [ ] Drift report generated and stored in `memory/YYYY-MM-DD.md` for all managed files
 - [ ] Verbatim files are byte-identical across repos
 - [ ] Templated files use correct repo-specific values
-- [ ] PRs opened for all SDK repos with drift
+- [ ] PRs opened only for SDK repos with drift (skip repos that are already in sync)
 - [ ] No files outside the managed list were modified


### PR DESCRIPTION
Updates maintainer skills so the bot only comments when it adds value. Replaces the “always respond” rule with guidance on when to comment, when to label only, and when to skip GitHub activity and log to memory instead.