### PR TITLE
Add stack roster and reviewer selection signals

### DIFF
--- a/USER.md
+++ b/USER.md
@@ -22,20 +22,22 @@ Altertable is an AI-native data platform — a SQL lakehouse with always-on agen
 
 ## Core Team
 
-| Name | GitHub | Slack |
-|---|---|---|
-| François Chalifour | [@francoischalifour](https://github.com/francoischalifour) | `francois` |
-| Florian Valeye | [@fvaleye](https://github.com/fvaleye) | `Florian` |
-| Léo Ercolanelli | [@leo-altertable](https://github.com/leo-altertable) | `Léo` |
-| Sylvain Utard | [@redox](https://github.com/redox) | `Sylvain` |
-| Robin Verdier | [@robinvrd](https://github.com/robinvrd) | `Robin` |
-| Kevin Granger | [@Shipow](https://github.com/Shipow) | `Kevin` |
-| Yannick Utard | [@utay](https://github.com/utay) | `Yannick` |
+**Stack** — Languages and related tech (e.g. GraphQL, React, Terraform) for reviewer routing. Used only as a tie-breaker after ownership signals; see [rules/team.md](rules/team.md). Not exclusive — anyone may review. Update via PR when this drifts.
+
+| Name | GitHub | Slack | Stack |
+|---|---|---|---|
+| Florian Valeye | [@fvaleye](https://github.com/fvaleye) | `Florian` | Go, Python, Ruby, Rust, Scala |
+| François Chalifour | [@francoischalifour](https://github.com/francoischalifour) | `francois` | GraphQL, JavaScript, Kotlin, React, Swift, TypeScript |
+| Kevin Granger | [@Shipow](https://github.com/Shipow) | `Kevin` | JavaScript |
+| Léo Ercolanelli | [@leo-altertable](https://github.com/leo-altertable) | `Léo` | Python, Ruby, Rust |
+| Robin Verdier | [@robinvrd](https://github.com/robinvrd) | `Robin` | Java, JavaScript, Kotlin, Swift, TypeScript |
+| Sylvain Utard | [@redox](https://github.com/redox) | `Sylvain` | C++, Java, JavaScript, Ruby, TypeScript |
+| Yannick Utard | [@utay](https://github.com/utay) | `Yannick` | Helm, Python, Rust, Terraform |
 
 ## Operator Preferences
 
 - **Timezone:** Europe/Paris (CET/CEST)
-- **Review requests:** Always pick from active core team members — spread across the team, don't always pick the same person
+- **Review requests:** Pick core team reviewers via GitHub’s request-review UI; rotate load. Order of signals: **git blame** on touched hunks → **git history** on touched paths → **stack** column in the roster when the PR’s stack is clear and blame/history are inconclusive. Details: [rules/team.md](rules/team.md).
 - **Autonomy level:** High for triage and commenting; always request human review before merging or releasing
 - **Communication style:** Concise, technical, no filler — the team values directness
 - **Public-facing tone:** Welcoming to contributors, precise on technical feedback

--- a/rules/contribution.md
+++ b/rules/contribution.md
@@ -22,7 +22,7 @@ git checkout -b <new-branch> upstream/main
 
 ## Stacked PRs on contributor branches
 
-When a contributor PR has fixable issues (CI failures, missing changelog, obvious improvements), open a PR targeting the contributor's branch (`base: <contributor-branch>`) rather than blocking them. Assign the contributor, request review from a team member, and comment on the original PR linking to the stacked PR.
+When a contributor PR has fixable issues (CI failures, missing changelog, obvious improvements), open a PR targeting the contributor's branch (`base: <contributor-branch>`) rather than blocking them. Assign the contributor, request review from a core team member ([rules/team.md](team.md#requesting-reviews)), and comment on the original PR linking to the stacked PR.
 
 Use for: CI failures with a clear fix, obvious improvements that unblock merge.  
 Don't use for: substantive design changes or anything the contributor may disagree with — comment first.

--- a/rules/team.md
+++ b/rules/team.md
@@ -10,8 +10,16 @@ Core team roster is in `USER.md`. All members have equal privilege.
 
 ## Requesting reviews
 
-Always use GitHub's request review feature (don't rely on mentions alone). Pick from `USER.md`; spread across the team. Check recent commit activity to pick the right person:
+Always use GitHub's request review feature (don't rely on mentions alone). Pick from the core team in `USER.md`.
+
+**Order of signals** (use the first that yields a strong candidate; among equals, prefer someone who has not reviewed your recent PRs):
+
+1. **Git blame** — On files the PR changes, who owns the touched hunks? Prefer reviewers whose GitHub login matches those authors (and is on the core team).
+2. **Git history** — Recent commits on the same paths or directories (`git log` on touched paths, or path-scoped API queries).
+3. **Stack** — In `USER.md`, prefer reviewers whose listed stack overlaps the PR's main languages and tooling when blame and history are inconclusive.
+
+Example for recent authors on a path (history signal):
 
 ```bash
-gh api repos/<owner>/<repo>/commits --jq '.[].author.login' | head -20
+gh api repos/<owner>/<repo>/commits --path path/to/dir --jq '.[].author.login' | head -20
 ```

--- a/skills/routine-maintainer/SKILL.md
+++ b/skills/routine-maintainer/SKILL.md
@@ -7,7 +7,7 @@ description: Notification-driven maintainer routine to identify actionable work 
 
 Dispatched by the heartbeat. Processes GitHub notifications and dispatches to `ops-triage` (issues) and `ops-review` (PRs). Primary source of awareness: `gh api notifications`.
 
-**Rules:** [memory](../../rules/memory.md) · [communication](../../rules/communication.md) · [safety](../../rules/safety.md)
+**Rules:** [memory](../../rules/memory.md) · [communication](../../rules/communication.md) · [team](../../rules/team.md) · [safety](../../rules/safety.md)
 
 ## Action Priorities
 
@@ -16,13 +16,13 @@ Dispatched by the heartbeat. Processes GitHub notifications and dispatches to `o
 1. **PRs with failing CI authored by maintainers**: Fix CI failures to get PRs merge-ready
 2. **PRs with merge conflicts**: Resolve conflicts so PRs can be merged
 3. **PRs with `CHANGES_REQUESTED`**: Address feedback or respond to the reviewer
-4. **Own PRs unreviewed for 3+ days**: Re-request review from a different team member from `USER.md`
+4. **Own PRs unreviewed for 3+ days**: Re-request review from a core team member (pick per [rules/team.md](../../rules/team.md#requesting-reviews))
 
 ### High priority (same session)
 
 1. **Open issues without maintainer responses** (older than 7 days): Triage or respond
 2. **Issues labeled `needs-info` or `needs-repro`**: Follow up or attempt reproduction
-3. **Items labeled `needs-human-review` with no human response for 3+ days**: Post a follow-up comment pinging another team member from `USER.md` (re-escalation)
+3. **Items labeled `needs-human-review` with no human response for 3+ days**: Post a follow-up comment pinging a core team member from `USER.md`, chosen per [rules/team.md](../../rules/team.md#requesting-reviews) (re-escalation)
 
 ### Medium priority (this week)
 


### PR DESCRIPTION
Defines an explicit order for choosing core-team reviewers (git blame on touched hunks → history on touched paths → **Stack** column in `USER.md` when blame/history are weak). Adds per-person stack tags for routing, updates `rules/team.md` and `USER.md` operator preferences, and links stacked-PR and routine-maintainer flows to that rule.
