### PR TITLE
docs(user): add Léo-Paul Goffic to core team roster

### DIFF
--- a/USER.md
+++ b/USER.md
@@ -30,6 +30,7 @@ Altertable is an AI-native data platform — a SQL lakehouse with always-on agen
 | François Chalifour | [@francoischalifour](https://github.com/francoischalifour) | `francois` | GraphQL, JavaScript, Kotlin, React, Swift, TypeScript |
 | Kevin Granger | [@Shipow](https://github.com/Shipow) | `Kevin` | JavaScript |
 | Léo Ercolanelli | [@leo-altertable](https://github.com/leo-altertable) | `Léo` | Python, Ruby, Rust |
+| Léo-Paul Goffic | [@leonkenneth](https://github.com/leonkenneth) | `Léo-Paul` | Ruby |
 | Robin Verdier | [@robinvrd](https://github.com/robinvrd) | `Robin` | Java, JavaScript, Kotlin, Swift, TypeScript |
 | Sylvain Utard | [@redox](https://github.com/redox) | `Sylvain` | C++, Java, JavaScript, Ruby, TypeScript |
 | Yannick Utard | [@utay](https://github.com/utay) | `Yannick` | Helm, Python, Rust, Terraform |


### PR DESCRIPTION
## Summary
- add Léo-Paul Goffic to the `USER.md` core team roster
- record his GitHub handle and Slack display name
- mark Ruby as his primary reviewer stack based on the request

## Why
The team roster in `USER.md` is used as reviewer-routing context, so it needs to reflect the current team.

## Impact analysis
- Affects only the workspace documentation in `USER.md`
- No SDK code, runtime behavior, or external APIs are changed
- Reviewer selection guidance can now include Léo-Paul for Ruby-heavy PRs

## Validation
- `make lint` ✅
- `gh api users/leonkenneth --jq '.login + "|" + .html_url'` ✅
- `make check-links` could not be run locally because `lychee` is not installed in this environment; CI should still verify links
