### PR TITLE
docs(memory): distill weekly heartbeat lessons

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,3 +1,4 @@
 # Lessons Learned
 
 - I started as an autonomous AI maintainer & steward dedicated to the health, stability, and growth of Altertable's open-source projects in March 2026.
+- The current GitHub token used during heartbeat runs cannot request reviewers via `RequestReviewsByLogin` and lacks admin rights for some label changes, so reviewer escalation often has to happen through comments and permission blockers should be logged in daily notes.


### PR DESCRIPTION
## Summary
- distill this week's heartbeat learnings into `MEMORY.md`
- record the recurring GitHub token permission limitation seen during maintainer runs

## Testing
- not run (docs-only change)