### PR TITLE
docs: require semantic PR titles for release-please repos

### DIFF
--- a/skills/sdk-release/SKILL.md
+++ b/skills/sdk-release/SKILL.md
@@ -67,6 +67,22 @@ Use **release-please** GitHub Action for:
 3. GitHub Release creation with release notes.
 4. Triggering registry publish on release.
 
+Because Altertable squash-merges pull requests and release-please derives release notes and version bumps from the merged commit subject, every repository using release-please must validate pull request titles in CI. The required gate is a dedicated GitHub Actions workflow using `amannn/action-semantic-pull-request@v5`, triggered on `pull_request_target` for `opened`, `edited`, and `synchronize`. Allowed title types are:
+
+- `feat`
+- `fix`
+- `perf`
+- `revert`
+- `docs`
+- `style`
+- `chore`
+- `refactor`
+- `test`
+- `build`
+- `ci`
+
+Name the workflow clearly (for example `Semantic Pull Request`), keep it separate from language-specific CI when possible, and treat missing PR-title validation as release automation drift that must be patched across affected repositories.
+
 Commit message prefixes:
 
 | Prefix | Version Bump |


### PR DESCRIPTION
## Summary
- document that release-please repos must validate PR titles with a semantic pull request workflow
- record the required trigger and allowed conventional commit types
- treat missing PR title validation as release automation drift that should be patched across affected repos

## Why
Altertable squash-merges PRs and release-please derives changelog entries and version bumps from the merged PR title. Without CI validation, a malformed PR title can break release automation or produce noisy release notes.

## Testing
- not applicable (documentation change)
