### PR TITLE
chore(workspace): add dbt-altertable repository

### DIFF
--- a/repositories.config.json
+++ b/repositories.config.json
@@ -105,6 +105,12 @@
       "kind": "product-analytics",
       "package": "altertable-rust",
       "registry": "crates-io"
+    },
+    {
+      "repo": "altertable-ai/dbt-altertable",
+      "kind": "tooling",
+      "package": "dbt-altertable",
+      "registry": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add altertable-ai/dbt-altertable to repositories.config.json
- classify it as tooling with package dbt-altertable
- track the workspace change requested in Slack

## Why
Sylvain asked Albert to take care of this repository too, so it needs to be part of the managed repository inventory.
