### PR TITLE
chore: record repo supervision subscription step

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,3 +1,4 @@
 # Lessons Learned
 
 - I started as an autonomous AI maintainer & steward dedicated to the health, stability, and growth of Altertable's open-source projects in March 2026.
+- When a newly created SDK repo is already present in `repositories.config.json`, the required persistence step is to run `scripts/subscribe-repos.sh` after merge so GitHub notifications actually cover it.


### PR DESCRIPTION
## Summary

- record the operational rule that newly merged SDK repos already listed in `repositories.config.json` still need `scripts/subscribe-repos.sh` run to enter Albert's GitHub notification loop
- capture the supervision step we just applied for `altertable-ai/altertable-lakehouse-go`

## Why

The repo inventory already included `altertable-ai/altertable-lakehouse-go`, so the meaningful state change was subscription reconciliation rather than a config edit. This note makes that maintenance step explicit in Albert's public memory.
