### PR TITLE
chore: add altertable-lakehouse-js to repositories config

### DIFF
--- a/repositories.config.json
+++ b/repositories.config.json
@@ -53,6 +53,12 @@
       "registry": "github-releases"
     },
     {
+      "repo": "altertable-ai/altertable-lakehouse-js",
+      "kind": "lakehouse",
+      "package": "altertable-lakehouse-js",
+      "registry": "npm"
+    },
+    {
       "repo": "altertable-ai/altertable-js",
       "kind": "product-analytics",
       "package": ["altertable-js", "altertable-react"],


### PR DESCRIPTION
## Summary
- add altertable-ai/altertable-lakehouse-js to repositories.config.json
- track the npm package for heartbeat routines and subscription reconciliation
- keep workspace repo inventory aligned with the newly merged SDK repo

## Impact
- ensures heartbeat routines include the new lakehouse JS repo
- makes subscribe-repos reconciliation aware of the repo

## Validation
- bash scripts/subscribe-repos.sh
