### PR TITLE
fix: document review handoff policy

### DIFF
--- a/USER.md
+++ b/USER.md
@@ -38,7 +38,7 @@ Altertable is an AI-native data platform — a SQL lakehouse with always-on agen
 ## Operator Preferences
 
 - **Timezone:** Europe/Paris (CET/CEST)
-- **Review requests:** Pick core team reviewers via GitHub’s request-review UI; rotate load. Order of signals: **git blame** on touched hunks → **git history** on touched paths → **stack** column in the roster when the PR’s stack is clear and blame/history are inconclusive. Details: [rules/team.md](rules/team.md).
+- **Review requests:** Pick core team reviewers, then leave a concise PR comment tagging the selected reviewer. Albert is not a repo maintainer and should not use GitHub's request-review assignment feature. Rotate load. Order of signals: **git blame** on touched hunks → **git history** on touched paths → **stack** column in the roster when the PR's stack is clear and blame/history are inconclusive. Details: [rules/team.md](rules/team.md).
 - **Autonomy level:** High for triage and commenting; always request human review before merging or releasing
 - **Communication style:** Concise, technical, no filler — the team values directness
 - **Public-facing tone:** Welcoming to contributors, precise on technical feedback

--- a/rules/contribution.md
+++ b/rules/contribution.md
@@ -22,7 +22,7 @@ git checkout -b <new-branch> upstream/main
 
 ## Stacked PRs on contributor branches
 
-When a contributor PR has fixable issues (CI failures, missing changelog, obvious improvements), open a PR targeting the contributor's branch (`base: <contributor-branch>`) rather than blocking them. Assign the contributor, request review from a core team member ([rules/team.md](team.md#requesting-reviews)), and comment on the original PR linking to the stacked PR.
+When a contributor PR has fixable issues (CI failures, missing changelog, obvious improvements), open a PR targeting the contributor's branch (`base: <contributor-branch>`) rather than blocking them. Assign the contributor if GitHub permits it, ask a core team member to review via a PR comment ([rules/team.md](team.md#requesting-reviews)), and comment on the original PR linking to the stacked PR.
 
 Use for: CI failures with a clear fix, obvious improvements that unblock merge.  
 Don't use for: substantive design changes or anything the contributor may disagree with — comment first.

--- a/rules/team.md
+++ b/rules/team.md
@@ -4,13 +4,13 @@ Core team roster is in `USER.md`. All members have equal privilege.
 
 ## Reviewing PRs
 
-- **Never review your own PRs.** If you authored or co-authored a PR, skip it entirely — request a review from a team member instead.
+- **Never review your own PRs.** If you authored or co-authored a PR, skip it entirely and ask a team member to review instead.
 - **Team PRs**: Concise. Focus on correctness, edge cases, test coverage. Skip style nitpicks. Trust their architecture judgment — raise concerns, don't block.
 - **External PRs**: Welcoming. Clear, actionable feedback with examples. Offer to help if changes are close.
 
 ## Requesting reviews
 
-Always use GitHub's request review feature (don't rely on mentions alone). Pick from the core team in `USER.md`.
+Albert is not a repo maintainer and should not use GitHub's request-review assignment feature. Pick a reviewer from the core team in `USER.md`, then leave a concise PR comment tagging that reviewer and stating why their review is requested.
 
 **Order of signals** (use the first that yields a strong candidate; among equals, prefer someone who has not reviewed your recent PRs):
 
@@ -21,5 +21,11 @@ Always use GitHub's request review feature (don't rely on mentions alone). Pick 
 Example for recent authors on a path (history signal):
 
 ```bash
-gh api repos/<owner>/<repo>/commits --path path/to/dir --jq '.[].author.login' | head -20
+gh api repos/<owner>/<repo>/commits -X GET -f path=path/to/dir --jq '.[].author.login' | head -20
+```
+
+Comment format:
+
+```text
+@reviewer could you review this when you have a slot? CI is green and this touches <area>.
 ```

--- a/skills/routine-maintainer/SKILL.md
+++ b/skills/routine-maintainer/SKILL.md
@@ -16,7 +16,7 @@ Dispatched by the heartbeat. Processes GitHub notifications and dispatches to `o
 1. **PRs with failing CI authored by maintainers**: Fix CI failures to get PRs merge-ready
 2. **PRs with merge conflicts**: Resolve conflicts so PRs can be merged
 3. **PRs with `CHANGES_REQUESTED`**: Address feedback or respond to the reviewer
-4. **Own PRs unreviewed for 3+ days**: Re-request review from a core team member (pick per [rules/team.md](../../rules/team.md#requesting-reviews))
+4. **Own PRs unreviewed for 3+ days**: Ask a core team member to review via a concise PR comment (pick per [rules/team.md](../../rules/team.md#requesting-reviews))
 
 ### High priority (same session)
 
@@ -48,7 +48,7 @@ Dispatched by the heartbeat. Processes GitHub notifications and dispatches to `o
    - Restating what the UI already shows (e.g. "CI is passing" when the green checkmark is visible)
    - Obvious observations (e.g. "This PR adds a new function" when reviewing the diff)
    - Redundant confirmations (e.g. "Approved!" when the approval badge is sufficient)
-5. **PRs**: CI failing → fix + push; changes requested → address + re-request review; conflicts → rebase + push
+5. **PRs**: CI failing → fix + push; changes requested → address + ask for review in a PR comment; conflicts → rebase + push
 6. **Issues**: untriaged → `ops-triage`; needs response → answer or request info; needs repro → attempt locally
 
 ## Acceptance Checklist


### PR DESCRIPTION
## Summary

- document that Albert should not use GitHub's request-review assignment feature
- switch review handoffs to concise PR comments tagging the selected core reviewer
- align maintainer routine and stacked-PR guidance with that boundary
- fix the `gh api` path-scoped commit history example while touching `rules/team.md`

## Rationale

Albert is intentionally not a repo maintainer. Review assignment failures from `RequestReviews` are expected policy boundaries, not permission problems to fix by granting maintainer access.

## Validation

- `make lint`
