### PR TITLE
Add altertable CLI repository

### DIFF
--- a/repositories.config.json
+++ b/repositories.config.json
@@ -117,6 +117,12 @@
       "kind": "tooling",
       "package": "dbt-altertable",
       "registry": "github-releases"
+    },
+    {
+      "repo": "altertable-ai/altertable-cli",
+      "kind": "tooling",
+      "package": "@altertable/cli",
+      "registry": "npm"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add `altertable-ai/altertable-cli` to `repositories.config.json`
- classify it as `tooling` with npm package `@altertable/cli`

## Validation
- `jq empty repositories.config.json`
- `git diff --check`
- `make lint`

## Follow-up
- after merge, run `bash scripts/subscribe-repos.sh` to reconcile GitHub watch subscriptions
