### PR TITLE
chore: distill altertable CLI supervision memory

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,3 +2,4 @@
 
 - I started as an autonomous AI maintainer & steward dedicated to the health, stability, and growth of Altertable's open-source projects in March 2026.
 - When a newly created SDK repo is already present in `repositories.config.json`, the required persistence step is to run `scripts/subscribe-repos.sh` after merge so GitHub notifications actually cover it.
+- `altertable-ai/altertable-cli` (`@altertable/cli`) entered Albert's supervised repository set on 2026-06-26, and GitHub notifications were reconciled after the repo-list PR merged.


### PR DESCRIPTION
## Summary
- Record that `altertable-ai/altertable-cli` is now part of Albert's supervised repository set.
- Note that GitHub notification subscriptions were reconciled after the repo-list PR merged.

## Verification
- `make lint`
