### PR TITLE
Silence routine heartbeat Slack updates

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -31,6 +31,15 @@ On full heartbeats (poll payload says full, or not yet run today per `code/heart
 2. **Weekly report** (Friday only) — use `ops-report`.
 3. **Distill MEMORY.md** (Friday only, after report) — read the week's daily notes, distill into `MEMORY.md`, open a PR.
 
+## Slack visibility
+
+Routine heartbeat runs must not post status updates to Slack channels or
+threads. Use local state (`code/heartbeat-state.json` and daily notes) for
+continuity, and use GitHub issues/PR comments for repo-specific follow-up.
+Only notify Slack when the heartbeat discovers something that needs immediate
+human input, when a human explicitly asks for a status update, or when a prior
+Slack thread is the active place to close an assigned request.
+
 ## Completion
 
 When a cycle creates durable context, record it in `memory/YYYY-MM-DD.md`. When a cycle leaves retries, blockers, or deferred work, update `code/heartbeat-state.json`. When nothing was actionable, no daily-note entry is required — return HEARTBEAT_OK.

--- a/rules/communication.md
+++ b/rules/communication.md
@@ -40,6 +40,7 @@ EOF
 - Lead with the actionable item. Use threads for detail. React with emoji when that's enough.
 - Treat a 👍 reaction on your Slack message as an approval (e.g., for a proposed action or decision).
 - When asked to update your configuration/instructions on Slack: update the local config (markdown, rules, skills, etc.), then open a PR so the team can review and merge. The goal is to always keep your local configuration in sync with the configuration on GitHub.
+- Heartbeats are silent in Slack by default. Do not post routine heartbeat summaries, unchanged status, or bare completion tokens to channels or threads. Notify Slack only when human input is needed, a human explicitly requested the update, or the Slack thread is the active place to close an assigned request.
 
 ## Tone
 


### PR DESCRIPTION
## Summary
- add an explicit heartbeat Slack visibility rule: routine runs stay silent in channels/threads
- update Slack communication rules to suppress routine summaries, unchanged status, and bare completion tokens
- keep Slack notification only for immediate human input, explicit status requests, or active assigned Slack threads

## Rationale
Sylvain asked that regular heartbeat runs stop posting Slack updates. The heartbeat should keep continuity in local state and GitHub artifacts, not notify the channel on every cadence.

## Validation
- `bash scripts/validate-workspace.sh`
- `make lint`
