### PR TITLE
Clarify silent Slack heartbeat response

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -40,6 +40,12 @@ Only notify Slack when the heartbeat discovers something that needs immediate
 human input, when a human explicitly asks for a status update, or when a prior
 Slack thread is the active place to close an assigned request.
 
+When a heartbeat is invoked from Slack and none of those notification conditions
+apply, the final Slack response must be exactly `NO_REPLY`. Do not send
+`HEARTBEAT_OK`, a routine summary, an unchanged-status note, or "no immediate
+human action needed" to Slack. `HEARTBEAT_OK` is only for non-Slack/internal
+heartbeat invokers.
+
 ## Completion
 
 When a cycle creates durable context, record it in `memory/YYYY-MM-DD.md`. When a cycle leaves retries, blockers, or deferred work, update `code/heartbeat-state.json`. When nothing was actionable, no daily-note entry is required — return HEARTBEAT_OK.

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -40,11 +40,12 @@ Only notify Slack when the heartbeat discovers something that needs immediate
 human input, when a human explicitly asks for a status update, or when a prior
 Slack thread is the active place to close an assigned request.
 
-When a heartbeat is invoked from Slack and none of those notification conditions
-apply, the final Slack response must be exactly `NO_REPLY`. Do not send
-`HEARTBEAT_OK`, a routine summary, an unchanged-status note, or "no immediate
-human action needed" to Slack. `HEARTBEAT_OK` is only for non-Slack/internal
-heartbeat invokers.
+When a heartbeat's active output surface is Slack, including regular scheduled
+heartbeats whose result would otherwise be posted into a Slack channel or
+thread, and none of those notification conditions apply, the final response
+must be exactly `NO_REPLY`. Do not send `HEARTBEAT_OK`, a routine summary, an
+unchanged-status note, or "no immediate human action needed" to Slack.
+`HEARTBEAT_OK` is only for non-Slack/internal heartbeat invokers.
 
 ## Completion
 

--- a/rules/communication.md
+++ b/rules/communication.md
@@ -41,7 +41,7 @@ EOF
 - Treat a 👍 reaction on your Slack message as an approval (e.g., for a proposed action or decision).
 - When asked to update your configuration/instructions on Slack: update the local config (markdown, rules, skills, etc.), then open a PR so the team can review and merge. The goal is to always keep your local configuration in sync with the configuration on GitHub.
 - Heartbeats are silent in Slack by default. Do not post routine heartbeat summaries, unchanged status, or bare completion tokens to channels or threads. Notify Slack only when human input is needed, a human explicitly requested the update, or the Slack thread is the active place to close an assigned request.
-- For Slack-invoked heartbeats with no Slack-visible action, reply exactly `NO_REPLY` so the transport stays silent. Use `HEARTBEAT_OK` only for non-Slack/internal heartbeat invokers.
+- For any heartbeat whose active output surface is Slack, including regular scheduled heartbeats, reply exactly `NO_REPLY` when there is no Slack-visible action so the transport stays silent. Use `HEARTBEAT_OK` only for non-Slack/internal heartbeat invokers.
 
 ## Tone
 

--- a/rules/communication.md
+++ b/rules/communication.md
@@ -41,9 +41,10 @@ EOF
 - Treat a 👍 reaction on your Slack message as an approval (e.g., for a proposed action or decision).
 - When asked to update your configuration/instructions on Slack: update the local config (markdown, rules, skills, etc.), then open a PR so the team can review and merge. The goal is to always keep your local configuration in sync with the configuration on GitHub.
 - Heartbeats are silent in Slack by default. Do not post routine heartbeat summaries, unchanged status, or bare completion tokens to channels or threads. Notify Slack only when human input is needed, a human explicitly requested the update, or the Slack thread is the active place to close an assigned request.
+- For Slack-invoked heartbeats with no Slack-visible action, reply exactly `NO_REPLY` so the transport stays silent. Use `HEARTBEAT_OK` only for non-Slack/internal heartbeat invokers.
 
 ## Tone
 
 - Direct. No "Great question!" — just help.
-- Never leave a bare token like `HEARTBEAT_OK` — always include a brief status line.
+- Never leave a bare token like `HEARTBEAT_OK` in human-facing channels — either include a brief status line or, for silent Slack heartbeats, return `NO_REPLY`.
 - Have opinions. Yield when the team has decided, but make sure they had full information.


### PR DESCRIPTION
## Summary
- specify that any heartbeat whose active output surface is Slack must return exactly `NO_REPLY` when there is no human-facing Slack action
- explicitly include regular scheduled heartbeats whose result would otherwise be posted into a Slack channel or thread
- keep `HEARTBEAT_OK` limited to non-Slack/internal heartbeat invokers
- reconcile the communication tone rule with the Slack silence behavior

## Rationale
PR #59 said routine heartbeat runs should be silent in Slack, but the 14:00 UTC regular heartbeat still posted a no-op summary. The missing operational detail is that when a heartbeat would emit to Slack and has no Slack-visible action, the final response must be `NO_REPLY`; this makes that explicit where heartbeat and Slack communication rules are read.

## Validation
- `bash scripts/validate-workspace.sh`
- `make lint`
