### PR TITLE
chore(workspace): track Metabase driver

### DIFF
--- a/repositories.config.json
+++ b/repositories.config.json
@@ -124,5 +124,11 @@
       "package": "@altertable/cli",
       "registry": "npm"
     }
+  ],
+  "projects": [
+    {
+      "repo": "altertable-ai/metabase-driver",
+      "kind": "integration"
+    }
   ]
 }

--- a/scripts/subscribe-repos.sh
+++ b/scripts/subscribe-repos.sh
@@ -34,7 +34,7 @@ fi
 
 CONFIG_REPOS=()
 while IFS= read -r line; do CONFIG_REPOS+=("$line"); done \
-  < <(jq -r '.sdks[].repo, .workspace.repo' "$CONFIG_FILE")
+  < <(jq -r '.sdks[].repo, .projects[]?.repo, .workspace.repo' "$CONFIG_FILE")
 
 # ── Load currently watched altertable-ai/* repos ──────────────────────────────
 # GitHub paginates at 100; loop pages until the response is empty.


### PR DESCRIPTION
## Summary

- Add `altertable-ai/metabase-driver` as a supervised non-SDK integration.
- Include non-SDK projects in the GitHub subscription reconciler while leaving spec-status checks scoped to SDKs.

## Impact analysis

The Metabase driver will be included in repository-watch reconciliation and therefore GitHub-notification-driven maintenance. It is deliberately excluded from the SDK list because it does not use `altertable-client-specs`; classifying it as an SDK would cause false missing-spec alerts and invoke the bootstrap workflow incorrectly.

## Validation

- `jq empty repositories.config.json`
- `bash -n scripts/subscribe-repos.sh`
- `bash scripts/validate-workspace.sh`

## Follow-up

GitHub currently returns 404 for the target repository to this account, so it cannot yet be watched. After this PR merges and repository visibility is available, run `bash scripts/subscribe-repos.sh` to reconcile the subscription.
