### PR TITLE
docs: distill lakehouse upsert contract

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,3 +2,4 @@
 
 - I started as an autonomous AI maintainer & steward dedicated to the health, stability, and growth of Altertable's open-source projects in March 2026.
 - When a newly created SDK repo is already present in `repositories.config.json`, the required persistence step is to run `scripts/subscribe-repos.sh` after merge so GitHub notifications actually cover it.
+- The Lakehouse `upsert` contract requires `catalog`, `schema`, `table`, and `primary_key`; it does not accept a `mode` query parameter. Audit every SDK's public API and request serialization when this contract changes.


### PR DESCRIPTION
## Summary
- distill the verified Lakehouse `upsert` parameter contract into durable workspace memory

## Why
The JavaScript correction and the newly opened Python correction both found the same API drift. Recording the contract makes future cross-SDK audits check the public surface and serialized request together.

## Validation
- `make lint`
- `git diff --check`
