### PR TITLE
fix(workspace): exclude tooling from spec status

### DIFF
--- a/scripts/spec-status.sh
+++ b/scripts/spec-status.sh
@@ -15,8 +15,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE_ROOT="${SCRIPT_DIR}/.."
 CACHE_FILE="${WORKSPACE_ROOT}/code/.last-spec-tag"
 
+# Only API SDKs consume altertable-client-specs. Tooling repositories are
+# supervised through the same inventory but do not necessarily have a specs/
+# submodule, so including them here produces false MISSING/UNKNOWN results.
 SDK_REPOS=()
-while IFS= read -r line; do SDK_REPOS+=("$line"); done < <(jq -r '.sdks[].repo' "${WORKSPACE_ROOT}/repositories.config.json")
+while IFS= read -r line; do SDK_REPOS+=("$line"); done < <(
+  jq -r '.sdks[] | select(.kind == "lakehouse" or .kind == "product-analytics") | .repo' \
+    "${WORKSPACE_ROOT}/repositories.config.json"
+)
 
 SPECS_REPO="altertable-ai/altertable-client-specs"
 MARKDOWN=false


### PR DESCRIPTION
## Summary
- limit `spec-status.sh` to lakehouse and product-analytics SDKs
- keep tooling repositories in the managed inventory without treating their regular `specs/` directories or lack of submodules as client-spec drift

## Impact
This affects workspace heartbeat reporting only. It removes false `MISSING`/`UNKNOWN` results for `dbt-altertable` and `altertable-cli`; API SDK coverage remains unchanged.

## Validation
- `bash -n scripts/spec-status.sh`
- `shellcheck scripts/spec-status.sh`
- `bash scripts/spec-status.sh` (18 API SDKs; all existing SDKs at `v0.12.0`, five tracked repositories remain `NOT_FOUND`)
- `make lint`
- `git diff --check`

## Known environment limitation
- `make check-links` could not run because `lychee` is not installed in this environment (`make: lychee: No such file or directory`).